### PR TITLE
Fix dark mode background

### DIFF
--- a/src/components/ExperienceItem.astro
+++ b/src/components/ExperienceItem.astro
@@ -13,7 +13,7 @@ const { title, company, description, link, date } = Astro.props
 ---
 
 <div
-  class="relative mx-12 pb-12 grid before:absolute before:left-[-35px] before:block before:h-full before:border-l-2 before:border-black/20 dark:before:border-white/15 before:content-[''] md:grid-cols-5 md:gap-10 md:space-x-4]"
+  class="relative mx-12 pb-12 grid before:absolute before:left-[-35px] before:block before:h-full before:border-l-2 before:border-black/20 dark:before:border-white/15 before:content-[''] md:grid-cols-5 md:gap-10 md:space-x-4"
 >
   <div class="relative pb-12 md:col-span-2">
     <div class="sticky top-0">

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -36,7 +36,11 @@ const { description, title } = Astro.props
       html {
         font-family: "Onest Variable", system-ui, sans-serif;
         scroll-behavior: smooth;
-        
+        background-color: white;
+      }
+
+      html.dark {
+        background-color: #060223;
       }
 
       body {


### PR DESCRIPTION
## Summary
- set html background color in dark mode so radial gradient edges stay dark

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_683f45d7a3c8833080b831801be0e9d8